### PR TITLE
Fix the default url changed in #2

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -126,7 +126,7 @@
 </head>
 
 <body>
-  <iframe id="webview" src="https://demo.immichframe.online/"></iframe>
+  <iframe id="webview"></iframe>
   <!-- Invisible buttons -->
   <button id="btnSettings" class="invisible-button"></button>
   <button id="btnQuit" class="invisible-button"></button>

--- a/src/main.js
+++ b/src/main.js
@@ -9,7 +9,7 @@ window.addEventListener("DOMContentLoaded", async () => {
   const urlInput = document.getElementById("urlInput");
   const saveUrlBtn = document.getElementById("saveUrl");
   const iframe = document.getElementById("webview");
-  const defaultUrl = "https://immichframe.github.io/ImmichFrame/";
+  const defaultUrl = "https://demo.immichframe.online/";
   
   try {
     const savedUrl = await invoke("read_url_from_file") || "";


### PR DESCRIPTION
The iframe src is always replaced by the Javascript so only set the URL in one place to avoid any issue later.

See https://github.com/immichFrame/ImmichFrame_Desktop/pull/3#issuecomment-3106578036